### PR TITLE
Fijar versión `Werkzeug` y eliminar `python-memcached`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ simplejson
 shapely
 pillow
 psycopg2
-python-memcached
 mapbox-vector-tile==1.2.0
-Werkzeug==0.11.13
+Werkzeug==0.16.1


### PR DESCRIPTION
## Objetivos

- Fijar el `Werkzeug` a la versión `0.16.1` para que esté alineado con el resto de aplicaciones del stack GIS
- Eliminar el `python-memcached` de los requerimientos